### PR TITLE
gives Confessor the Inquisitor combat music

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/confessor
 	category_tags = list(CTAG_INQUISITION)
-	cmode_music = 'sound/music/combat_rogue.ogg'
+	cmode_music = 'sound/music/inquisitorcombat.ogg'
 
 /datum/outfit/job/roguetown/confessor
 	job_bitflag = BITFLAG_CHURCH
@@ -38,7 +38,7 @@
 			H.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			beltr = /obj/item/quiver/arrows
-	H.set_blindness(0)		
+	H.set_blindness(0)
 	cloak = /obj/item/clothing/suit/roguetown/armor/longcoat
 	wrists = /obj/item/clothing/neck/roguetown/psicross/silver
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather


### PR DESCRIPTION
## About The Pull Request

Confessor is a mini-inquisitor, so they should get the inquisitor combat music. Adjudicator already follows the same logic. Confessor currently uses the rogue combat music. For some reason.

## Testing Evidence

it is a single line of code
<img width="443" height="71" alt="image" src="https://github.com/user-attachments/assets/0fac360b-d8af-4305-8a02-fca79d8f089c" />


## Why It's Good For The Game

![Untitled](https://github.com/user-attachments/assets/b9f8b709-f8e9-4cd7-8b4d-9321f7009b47)
